### PR TITLE
Migration to CM API v4

### DIFF
--- a/CampaignManagerDAO.js
+++ b/CampaignManagerDAO.js
@@ -75,8 +75,16 @@ var CampaignManagerDAO = function(profileId) {
       result = result.concat(response[listName]);
 
       if (response.nextPageToken) {
+        if(!options['ids']) {
+          // Possible bug. Keep sending options to filter the request such as campaignId, etc., in each call since the API 'loses' the params and starts retrieving
+          // elements in higher hierarchies, for example creatives at advertiser level instead of campaign level.
+          options['pageToken'] = response.nextPageToken;
+        } else {
+          // Don't do it when sending ids[] to filter the request since there is a 400 error about sending > 500 ids
+          options = {'pageToken': response.nextPageToken};
+        }
         response = _retry(function() {
-          return DoubleClickCampaigns[entity].list(profileId, {'pageToken': response.nextPageToken});
+          return DoubleClickCampaigns[entity].list(profileId, options);
         }, DEFAULT_RETRIES, DEFAULT_SLEEP);
       } else {
         response = null;

--- a/Fields.js
+++ b/Fields.js
@@ -22,27 +22,28 @@
 var fields = {
   // Common Fields
   'archived': 'Archived',
-  
+  'activeStatus': 'Active Status',
+
   // Advertiser
   'advertiserId': 'Advertiser ID',
   'advertiserName': 'Advertiser Name',
-  
+
   // Site
   'siteId': 'Site ID',
   'siteName': 'Site Name',
-  
+
   // Landing Page
   'landingPageId': 'Landing Page ID',
   'landingPageName': 'Landing Page Name',
   'landingPageUrl': 'Landing Page URL',
-  
+
   // Campaign
   'campaignId': 'Campaign ID',
   'campaignName': 'Campaign Name',
   'campaignStartDate': 'Campaign Start Date',
   'campaignEndDate': 'Campaign End Date',
   'billingInvoiceCode': 'Billing Invoice Code',
-  
+
   // Event Tag
   'eventTagId': 'Event Tag ID',
   'eventTagName': 'Event Tag Name',
@@ -51,7 +52,7 @@ var fields = {
   'eventTagType': 'Event Tag Type',
   'eventTagUrl': 'Event Tag URL',
   'enabled': 'Enabled',
-  
+
   // Placement Group
   'placementGroupId': 'Placement Group ID',
   'placementGroupName': 'Placement Group Name',
@@ -77,13 +78,18 @@ var fields = {
   'placementProgressOffsetPercentage': 'Progress Offset Percentage',
   'placementAdditionalKeyValues': 'Additional Key Values',
   'placementAssetSize': 'Asset Size',
+  'placementStatusUnknown': 'PLACEMENT_STATUS_UNKNOWN',
+  'placementStatusActive': 'PLACEMENT_STATUS_ACTIVE',
+  'placementStatusInactive': 'PLACEMENT_STATUS_INACTIVE',
+  'placementStatusArchived': 'PLACEMENT_STATUS_ARCHIVED',
+  'placementStatusPermanentlyArchived': 'PLACEMENT_STATUS_PERMANENTLY_ARCHIVED',
 
   // Placement Pricing Schedule
   'pricingPeriodStart': 'Pricing Period Start Date',
   'pricingPeriodEnd': 'Pricing Period End Date',
   'pricingPeriodRate': 'Pricing Period Rate',
   'pricingPeriodUnits': 'Pricing Period Units',
-  
+
   // Creative
   'creativeId': 'Creative ID',
   'creativeName': 'Creative Name',

--- a/Loaders.js
+++ b/Loaders.js
@@ -38,7 +38,7 @@ function getCreativeNameCreativeIdFeatureConfig() {
 }
 
 /*
- * Gets the FilterArchived flag from the store tab
+ * Gets the ActiveOnly flag from the store tab
  *
  * returns: boolean representing the value of the active flag
  */
@@ -1302,12 +1302,13 @@ var PlacementGroupLoader = function(cmDAO) {
     }
 
     if(getUnarchivedOnlyFlag()) {
-      searchOptions['archived'] = false;
+      searchOptions['activeStatus'] = [fields.placementStatusUnknown, fields.placementStatusActive, fields.placementStatusInactive];
     }
+
     return result;
   }
 
-  /**
+  /**F
    * @see CampaignLoader.mapFeed
    */
   this.mapFeed = function(placementGroup) {
@@ -1406,7 +1407,7 @@ var PlacementLoader = function(cmDAO) {
     }
 
     if(getUnarchivedOnlyFlag()) {
-      searchOptions['archived'] = false;
+      searchOptions['activeStatus'] = [fields.placementStatusUnknown, fields.placementStatusActive, fields.placementStatusInactive];
     }
 
     return result;
@@ -1427,7 +1428,7 @@ var PlacementLoader = function(cmDAO) {
     var feedItem = {};
     feedItem[fields.placementId] = placement.id;
     feedItem[fields.placementName] = placement.name;
-    feedItem[fields.archived] = placement.archived;
+    feedItem[fields.activeStatus] = placement.activeStatus;
 
     if (placement.vpaidAdapterChoice == 'HTML5' &&
         !placement.videoActiveViewOptOut) {
@@ -1728,7 +1729,7 @@ var PlacementLoader = function(cmDAO) {
     // Handle base fields
     this.assign(placement, 'name', feedItem, fields.placementName, true);
 
-    placement['archived'] = this.isTrue(feedItem[fields.archived]);
+    placement['activeStatus'] = feedItem[fields.activeStatus];
     placement['adBlockingOptOut'] = this.isTrue(feedItem[fields.adBlocking]);
 
     this.assign(placement, 'siteId', feedItem, fields.siteId, true);

--- a/README.md
+++ b/README.md
@@ -36,8 +36,7 @@ Bulkdozer is a Google Sheets-based tool leveraging Apps Script and the CM360 API
 Use the link below to navigate to the tool. Refer to the
 "Instructions" tab of for details on how to deploy and use the solution.
 
-- [Bulkdozer
-  0.39.3](https://docs.google.com/spreadsheets/d/1jVXiLiAS_n9-7v7Ekw52UzNE2bEiCi7CCmjWxKB7kcw/edit?usp=sharing)
+- [Bulkdozer 0.4](https://docs.google.com/spreadsheets/d/1jVXiLiAS_n9-7v7Ekw52UzNE2bEiCi7CCmjWxKB7kcw/edit?usp=sharing)
 
 ### Apps Script Advanced Service Configuration
 Due to recent Apps Scripts changes, an extra configuration is required for Bulkdozer to work properly. Please follow the steps below:
@@ -45,14 +44,13 @@ Due to recent Apps Scripts changes, an extra configuration is required for Bulkd
 2. In the Script Editor, navigate to the 'Editor' tab in the outer left nav (icon looks like '< >' brackets)
 3. Under the 'Services' section of the inner left nav, click on the vertical three-dots next to the 'DoubleClickCampaigns' service and click 'Remove' and then click 'Remove service' on the confirmation pop-up.
 4. Click the '+' button next to Services in the inner left nav to re-add the service.
-5. In the list of services select 'Campaign Manager 360 API' and check that the version is the latest or 'v3.5' at this time and that the 'Identifier' is the same 'DoubleClickCampaigns'.
+5. In the list of services select 'Campaign Manager 360 API' and check that the version is 'v4' at this time and that the 'Identifier' is the same 'DoubleClickCampaigns'.
 
 ## Solution Manual
 
 ### **Solution Setup, Basics & Legend**
 
-1. Make a Copy of the Bulkdozer Google Sheet [Bulkdozer
-  0.39.3](https://docs.google.com/spreadsheets/d/1jVXiLiAS_n9-7v7Ekw52UzNE2bEiCi7CCmjWxKB7kcw/edit?usp=sharing)
+1. Make a Copy of the Bulkdozer Google Sheet [Bulkdozer 0.4](https://docs.google.com/spreadsheets/d/1jVXiLiAS_n9-7v7Ekw52UzNE2bEiCi7CCmjWxKB7kcw/edit?usp=sharing)
 
 2. Your permissions in Bulkdozer are tied to your CM360 Profile’s Permission for a given CM360 Account. In the Store tab, next to profileid (Row 2B), input your CM360 Profile ID for the appropriate CM360 Account that you will be trafficking in. Without this, Bulkdozer will not work.
 
@@ -193,8 +191,9 @@ Sign up for updates and announcements:
 
 ## Other Resources
 
-The files below are a simplified version of [Bulkdozer 0.39.3](https://docs.google.com/spreadsheets/d/1jVXiLiAS_n9-7v7Ekw52UzNE2bEiCi7CCmjWxKB7kcw/edit?usp=sharing) and only include a specific Bulkdozer feature.
+The files below are a simplified version of [Bulkdozer 0.4](https://docs.google.com/spreadsheets/d/1jVXiLiAS_n9-7v7Ekw52UzNE2bEiCi7CCmjWxKB7kcw/edit?usp=sharing) and only include a specific Bulkdozer feature.
 
+**These modules are not actively maintained**
 - [QA Tools 0.15](https://docs.google.com/spreadsheets/d/10sZGoK8Z9BMb_6QKeOzJ4D698mJ4mNbtDY8ASfoyh9I/edit?usp=sharing)
 - [Event Tag QA Tool](https://docs.google.com/spreadsheets/d/1Pj4DqHibkTSoo6zQGDpksxpnxyhojNa3pBkMAvX0p6A/edit?usp=sharing&resourcekey=0-Vw7rukq3OH8cZLPR4IEk5g)
 - [Event Tag Editor 0.4](https://docs.google.com/spreadsheets/d/1_ox81ztsuxVaNsEjYvr783urGP41Hv1vnyP-hl0kUKo/edit?usp=sharing&resourcekey=0-CWepPTVXFFaBDg0CvD4rzg)


### PR DESCRIPTION
Migration to CM API v4. The following fields have been removed:
Campaigns
   - nielsenOcrEnabled
   - traffickerEmails
   - archived - IMPORTANT: doc says that it was removed, but it still appears in the API reference section. Need to check with API team Placements
   - archived - called activeStatus now PlacementGroups
   - archived - called activeStatus now The Archive column in the Placements tab has been replaced with Active Status with the new ENUM values for this field Fix bug for v4 in the CMDAO class where pagination was not considering the options (filters) sent, e.g campaignId. Sending the params in each API call now but only when no ids[] param is sent.